### PR TITLE
add versioning to makefile and wrapper script

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,5 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+version := $(shell cat VERSION)
+
 image:
-	docker build -t eu.gcr.io/gardener-project/sow -f docker/Dockerfile .
+	docker build -t eu.gcr.io/gardener-project/sow:$(version) -f docker/Dockerfile .

--- a/docker/bin/sow
+++ b/docker/bin/sow
@@ -18,6 +18,7 @@
 # Find parent folder of pwd directly under root
 rdir=${PWD#/}
 rdir="/${rdir%%/*}"
+version=$(cat "$(dirname "$0")/../../VERSION")
 
 # Docker run
-docker run --mount type=bind,src="$rdir",dst="/mounted$rdir" --workdir "/mounted$PWD" --rm  -it --user "$(id -u):$(id -g)" "eu.gcr.io/gardener-project/sow:latest" "$@"
+docker run --mount type=bind,src="$rdir",dst="/mounted$rdir" --workdir "/mounted$PWD" --rm  -it --user "$(id -u):$(id -g)" "eu.gcr.io/gardener-project/sow:$version" "$@"


### PR DESCRIPTION
The `sow` wrapper script now uses the image tagged with the version specified in the `VERSION` file. The `Makefile` has been changed accordingly (will now tag the created image with that version). 

The main advantage of this change is that downloading a new sow release will also affect the image that is used. Before, the wrapper script used the `latest` tag and if someone downloaded a new sow release, but forgot to delete or rebuild his local image, the wrapper script would still use the old sow code.

Please note that downloading the image only works for the releases. If you check out the `master` branch instead of a release, the `VERSION` file will contain something like `x.y.z-dev` and this tag won't be available in the image repository. It is, however, possible to build the fitting image locally using the `Makefile`. 