### PR TITLE
added retry logic to kubectl and helm plugin

### DIFF
--- a/plugins/helm/plugin
+++ b/plugins/helm/plugin
@@ -29,6 +29,8 @@ getRequiredValue namespace "namespace" PLUGINCONFIGJSON
 getValue command "command" PLUGINCONFIGJSON
 getValueList helm_flags_deploy "flags.deploy" PLUGINCONFIGJSON
 getValueList helm_flags_delete "flags.delete" PLUGINCONFIGJSON
+getValue retry_attempts "retry.attempts" PLUGINCONFIGJSON
+getValue retry_wait "retry.wait" PLUGINCONFIGJSON
 
 if [ -z "$command" ]; then
   command="${3:-"upgrade"}"
@@ -55,12 +57,21 @@ deploy() {
     info "Running helm $command for $name ..."
     case "$command" in
         upgrade)
-            exec_cmd helm upgrade --install --force --wait $name \
-                --kubeconfig "$KUBECONFIG" \
-                --values "$dir/values.json" \
-                --namespace $namespace \
-                $(echo "${helm_flags_deploy[@]}") \
-                "$src"
+            local attempts=${retry_attempts:-3}
+            local backoff=${retry_wait:-10}
+            while true; do
+                if exec_cmd helm upgrade --install --force --wait $name --kubeconfig "$KUBECONFIG" --values "$dir/values.json" --namespace $namespace $(echo "${helm_flags_deploy[@]}") "$src" ; then
+                    break
+                else
+                    attempts=$(( attempts - 1 ))
+                    if [[ $attempts -gt 0 ]]; then
+                        info "command failed, waiting for $backoff seconds and trying again ($attempts times)"
+                        sleep $backoff
+                    else
+                        fail "helm command failed and retry limit reached"
+                    fi
+                fi
+            done
             ;;
         template)
             cmd="helm template --name $name --kubeconfig \"$KUBECONFIG\" --values \"$dir/values.json\" --namespace $namespace $(echo "${helm_flags_deploy[@]}") \"$src\""
@@ -81,20 +92,26 @@ delete() {
         upgrade)
             info "Deleting helm deployment for $name"
             tmp="/tmp/helmplugin$$"
-            exec_cmd helm delete \
-                --kubeconfig "$KUBECONFIG" \
-                --purge \
-                $name \
-                $(echo "${helm_flags_delete[@]}") 2>"$tmp" || {
+            local attempts=${retry_attempts:-3}
+            local backoff=${retry_wait:-10}
+            while true; do
+                if exec_cmd helm delete --kubeconfig "$KUBECONFIG" --purge $name $(echo "${helm_flags_delete[@]}") 2>"$tmp" ; then
+                    break
+                else
                     error="$(cat "$tmp")"
-                    if [ "$error" != "Error: release: \"$name\" not found" ]; then
-                        rm -f "$tmp"
-                        fail "$error"
-                    else
+                    attempts=$(( attempts - 1 ))
+                    if [ "$error" = "Error: release: \"$name\" not found" ]; then
                         info "release $name already deleted"
+                        break
+                    elif [[ $attempts -gt 0 ]]; then
+                        info "command failed, waiting for $backoff seconds and trying again ($attempts times)"
+                        sleep $backoff
+                    else
+                        fail "helm command failed and retry limit reached"
                     fi
-                }
-                rm -f "$tmp"
+                fi
+            done
+            rm -f "$tmp"
             ;;
         template)
             ;;

--- a/plugins/helm/plugin
+++ b/plugins/helm/plugin
@@ -32,6 +32,9 @@ getValueList helm_flags_delete "flags.delete" PLUGINCONFIGJSON
 getValue retry_attempts "retry.attempts" PLUGINCONFIGJSON
 getValue retry_wait "retry.wait" PLUGINCONFIGJSON
 
+attempts=${retry_attempts:-5}
+backoff=${retry_wait:-15}
+
 if [ -z "$command" ]; then
   command="${3:-"upgrade"}"
 fi
@@ -57,8 +60,6 @@ deploy() {
     info "Running helm $command for $name ..."
     case "$command" in
         upgrade)
-            local attempts=${retry_attempts:-3}
-            local backoff=${retry_wait:-10}
             while true; do
                 if exec_cmd helm upgrade --install --force --wait $name --kubeconfig "$KUBECONFIG" --values "$dir/values.json" --namespace $namespace $(echo "${helm_flags_deploy[@]}") "$src" ; then
                     break
@@ -92,8 +93,6 @@ delete() {
         upgrade)
             info "Deleting helm deployment for $name"
             tmp="/tmp/helmplugin$$"
-            local attempts=${retry_attempts:-3}
-            local backoff=${retry_wait:-10}
             while true; do
                 if exec_cmd helm delete --kubeconfig "$KUBECONFIG" --purge $name $(echo "${helm_flags_delete[@]}") 2>"$tmp" ; then
                     break

--- a/plugins/kubectl/plugin
+++ b/plugins/kubectl/plugin
@@ -80,6 +80,8 @@ setKubeConfig()
 # $1: action
 # $2: kubeconfig file
 # $3: manifest file
+# $4: retry attempts (defaults to 1)
+# $5: retry waiting time in seconds (defaults to 10)
 exec_action()
 {
   local name
@@ -118,9 +120,45 @@ exec_action()
     verbose "    using handler $f"
     $f "$name" "$namespace" "$2" "$3"
   else
+    local attempts=${4:-""}
+    local backoff=${5:-""}
+    if [ -z "$attempts" ]; then
+      attempts=3
+    fi
+    if [ -z "$backoff" ]; then
+      backoff=10
+    fi
     case "$1" in
-      deploy) exec_cmd kubectl --kubeconfig "$2" apply -f "$3";;
-      delete) exec_cmd kubectl --kubeconfig "$2" delete -f "$3";;
+      deploy)
+        while true; do
+          if exec_cmd kubectl --kubeconfig "$2" apply -f "$3" ; then
+            break
+          else
+            attempts=$(( attempts - 1 ))
+            if [[ $attempts -gt 0 ]]; then
+              info "command failed, waiting for $backoff seconds and trying again ($attempts times)"
+              sleep $backoff
+            else
+              fail "kubectl command failed and retry limit reached"
+            fi
+          fi
+        done
+        ;;
+      delete)
+        while true; do
+          if exec_cmd kubectl --kubeconfig "$2" delete -f "$3" ; then
+            break
+          else
+            attempts=$(( attempts - 1 ))
+            if [[ $attempts -gt 0 ]]; then
+              info "command failed, waiting for $backoff seconds and trying again ($attempts times)"
+              sleep $backoff
+            else
+              fail "kubectl command failed and retry limit reached"
+            fi
+          fi
+        done
+        ;;
     esac
   fi
 }
@@ -132,6 +170,8 @@ exec_manifest()
   local kube="$3"
   local index="$4"
   local manifest="$5"
+  local retry_attempts="$6"
+  local retry_wait="$7"
 
   local kubeconfig="$TMP_KUBECONFIG"
   setKubeConfig "$type" "$kube" "$kubeconfig"
@@ -153,13 +193,13 @@ exec_manifest()
 
   if [ "$cmd" == deploy ]; then
     echo "$manifest" | spiff merge - >"$file"
-    exec_action "$cmd" "$kubeconfig" "$file"
+    exec_action "$cmd" "$kubeconfig" "$file" "$retry_attempts" "$retry_wait"
     setjsonvalue deployed 'clusters["'$api'"].kubeconfig' "$(cat "$kubeconfig")"
     setjsonjson deployed 'clusters["'$api'"].manifests["'$objectkey'"]' "$objectentry"
     executed["$api"]="${executed["$api"]} $objectkey"
   else
     if [ -f "$file" ]; then
-      exec_action "$cmd" "$kubeconfig" "$file"
+      exec_action "$cmd" "$kubeconfig" "$file" "$retry_attempts" "$retry_wait"
       deljsonkey deployed 'clusters["'$api'"].manifests["'$objectkey'"]'
     fi
   fi
@@ -262,7 +302,7 @@ save()
 
 execute_manifest()
 {
-  exec_manifest $1 "${kube[@]}" "$i-$2" "$3"
+  exec_manifest $1 "${kube[@]}" "$i-$2" "$3" "$4" "$5"
 }
 
 execute_file()
@@ -276,7 +316,7 @@ execute_file()
     fail "entry $i:$j: $f not found"
   fi
   while IFS= read -r line; do
-    exec_manifest $1 "${kube[@]}" "$i-$j" "$line"
+    exec_manifest $1 "${kube[@]}" "$i-$j" "$line" "$4" "$5"
   done < <(spiff merge --json "$file" | $order)
 }
 
@@ -296,9 +336,11 @@ execute_entry()
     fail no or empty kubeconfig configured
   fi
 
+  getValue retry_attempts "retry.attempts" entry
+  getValue retry_wait "retry.wait" entry
   getJSONList manifests manifests entry
   if [ ${#manifests[@]} -ne 0 ]; then
-    executionLoop "$1" manifests execute_manifest
+    executionLoop "$1" manifests execute_manifest "$retry_attempts" "$retry_wait"
   else
     getValueList files files entry
     getValueList args command entry
@@ -306,7 +348,7 @@ execute_entry()
       if [ ${#args[@]} -ne 0 ]; then
         fail "entry $i: only files or command possible"
       fi
-      executionLoop "$1" files execute_file
+      executionLoop "$1" files execute_file "$retry_attempts" "$retry_wait"
     elif [ ${#args[@]} -ne 0 ]; then
       found "command: ${#args[@]}: ${args[@]}"
       if _is_function "cmd_${args[0]}"; then

--- a/plugins/kubectl/plugin
+++ b/plugins/kubectl/plugin
@@ -123,10 +123,10 @@ exec_action()
     local attempts=${4:-""}
     local backoff=${5:-""}
     if [ -z "$attempts" ]; then
-      attempts=3
+      attempts=5
     fi
     if [ -z "$backoff" ]; then
-      backoff=10
+      backoff=15
     fi
     case "$1" in
       deploy)


### PR DESCRIPTION
To prevent the whole setup from failing when the apiserver is temporarily unavailable, the kubectl as well as the helm plugin now try several times, if the command doesn't succeed.

The default is 5 attempts while waiting 15 seconds in between. These values can be configured via the following block in the plugin's values:

```yaml
retry:
  attempts: 5
  wait: 15
```

If something gets deleted via kubectl because it was there in a previous deployment and isn't there in a new deployment, there is no place to specify these values, so in this case, the defaults will be used.