### PR TITLE
add possibility to define an installation handler

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,6 +198,19 @@ in the configuration (using _spiff_ features).
 The processing result is stored in `gen/config.json`. This file
 is used as stub for the processing of the other control files.
 
+The `meta.installationHandler` node can be used to configure an installation handler.
+
+```yaml
+meta:
+  installationHandler:
+    path: <path to executable bash file>
+    config: <optional, arbitrary yaml>
+```
+
+If configured, the referenced script will be called once before any call to `sow` (except for `sow version` and `sow help`) with argument `prepare` and once after the `sow` command with argument `finalize`. If the prepare step fails, neither the `sow` command, nor the finalize part will be executed. If the `sow` command fails, the finalize step will still be executed.
+
+Whatever you provide in the (optional) `config` node will be given to the script as a second argument in form of a JSON string.
+
 ### `component.yaml`
 
 This file indicates the root folder of a component. It is used by

--- a/bin/sow
+++ b/bin/sow
@@ -342,7 +342,8 @@ setupLandscape()
   fi
 
   if [ "$cmd" != "help" ]; then
-    getValue INSTALLATION_HANDLER "meta.installationHandler" CONFIGJSON
+    getValue INSTALLATION_HANDLER "meta.installationHandler.path" CONFIGJSON
+    getJSON INSTALLATION_HANDLER_CONFIG "meta.installationHandler.config" CONFIGJSON
     if [ -n ${INSTALLATION_HANDLER:-""} ]; then
       if [[ "$INSTALLATION_HANDLER" != /* ]]; then
         # relative to root folder if no absolute path given
@@ -351,7 +352,7 @@ setupLandscape()
       if [ ! -x "$INSTALLATION_HANDLER" ]; then
         fail "no executable installation handler script found at '$INSTALLATION_HANDLER'"
       fi
-      exec_cmd "$INSTALLATION_HANDLER" prepare
+      exec_cmd "$INSTALLATION_HANDLER" prepare "$INSTALLATION_HANDLER_CONFIG"
     fi
   fi
 }

--- a/bin/sow
+++ b/bin/sow
@@ -341,6 +341,19 @@ setupLandscape()
     fail "aborted due to dependency problems"
   fi
 
+  if [ "$cmd" != "help" ]; then
+    getValue INSTALLATION_HANDLER "meta.installationHandler" CONFIGJSON
+    if [ -n ${INSTALLATION_HANDLER:-""} ]; then
+      if [[ "$INSTALLATION_HANDLER" != /* ]]; then
+        # relative to root folder if no absolute path given
+        INSTALLATION_HANDLER="$ROOT/$INSTALLATION_HANDLER"
+      fi
+      if [ ! -x "$INSTALLATION_HANDLER" ]; then
+        fail "no executable installation handler script found at '$INSTALLATION_HANDLER'"
+      fi
+      exec_cmd "$INSTALLATION_HANDLER" prepare
+    fi
+  fi
 }
 
 isDeployed()

--- a/bin/sow
+++ b/bin/sow
@@ -352,7 +352,11 @@ setupLandscape()
       if [ ! -x "$INSTALLATION_HANDLER" ]; then
         fail "no executable installation handler script found at '$INSTALLATION_HANDLER'"
       fi
-      exec_cmd "$INSTALLATION_HANDLER" prepare "$INSTALLATION_HANDLER_CONFIG"
+      if ! exec_cmd "$INSTALLATION_HANDLER" prepare "$INSTALLATION_HANDLER_CONFIG"; then
+        # prepare failed, execute neither command nor finalize
+        unset INSTALLATION_HANDLER
+        fail "aborting command: prepare failed"
+      fi
     fi
   fi
 }

--- a/lib/action
+++ b/lib/action
@@ -248,8 +248,6 @@ action_deployment()
     esac
   fi
 
-  handle_state 
-
   ############################
   # cleanup 
   ############################
@@ -274,6 +272,7 @@ action_deployment()
     fi
   fi
   setState
+  handle_state
 }
 
 setState()

--- a/lib/utils
+++ b/lib/utils
@@ -51,6 +51,13 @@ handle_error()
     INTENDED_EXIT=X
     DEBUG=
   fi
+
+  if [ "$BASH_SUBSHELL" = "0" ] && [ -n ${INSTALLATION_HANDLER:-""} ]; then
+    if [ ! -x "$INSTALLATION_HANDLER" ]; then
+      fail "no executable installation handler script found at '$INSTALLATION_HANDLER'"
+    fi
+    exec_cmd "$INSTALLATION_HANDLER" finalize
+  fi
 }
 
 StandardErrorHandling()

--- a/lib/utils
+++ b/lib/utils
@@ -56,7 +56,7 @@ handle_error()
     if [ ! -x "$INSTALLATION_HANDLER" ]; then
       fail "no executable installation handler script found at '$INSTALLATION_HANDLER'"
     fi
-    exec_cmd "$INSTALLATION_HANDLER" finalize
+    exec_cmd "$INSTALLATION_HANDLER" finalize "$INSTALLATION_HANDLER_CONFIG"
   fi
 }
 

--- a/plugins/git/plugin
+++ b/plugins/git/plugin
@@ -22,32 +22,49 @@ getValue branch "branch" PLUGINCONFIGJSON
 getValue commit "commit" PLUGINCONFIGJSON
 getValueList files "files" PLUGINCONFIGJSON
 
-if [ -n "$tag" ]; then
-    # tag is given
-    prefix="refs/tags/"
-    ref="$tag"
-    mode="tag"
-    cmdmod="--branch $ref"
-elif [ -n "$branch" ]; then
-    # branch is given
-    prefix=
-    ref="$branch"
-    mode="branch"
-    cmdmod="--branch $ref"
-elif [ -n "$commit" ]; then
-    # commit is given
-    prefix=
-    ref="$commit"
-    mode="commit"
-    cmdmod=
-else
-    # nothing is given
-    fail "either 'tag', 'branch', or 'commit' attribute is required"
-fi
+checkout() {
+    if [ -n "$tag" ]; then
+        # tag is given
+        prefix="refs/tags/"
+        ref="$tag"
+        mode="tag"
+        cmdmod="--branch $ref"
+    elif [ -n "$branch" ]; then
+        # branch is given
+        prefix=
+        ref="$branch"
+        mode="branch"
+        cmdmod="--branch $ref"
+    elif [ -n "$commit" ]; then
+        # commit is given
+        prefix=
+        ref="$commit"
+        mode="commit"
+        cmdmod=
+    else
+        # nothing is given
+        fail "either 'tag', 'branch', or 'commit' attribute is required"
+    fi
 
-repo_path="$dir/repo"
+    repo_path="$dir/repo"
+    version_path="$dir/version.json"
+    version="{\"$mode\": \"$ref\"}"
 
-deploy() {
+    if [ -f "$version_path" ]; then
+        old_version=$(cat "$version_path")
+        if [[ "$old_version" == "$version" ]]; then
+            if missing_file=$(checkFiles "${files[@]}"); then
+                verbose "correct version already checked out, nothing to do"
+                return
+            else
+                verbose "correct version checked out, but file/directory '$missing_file' is missing"
+            fi
+        else
+            verbose "incorrect version checked out"
+        fi
+    fi
+
+    # checkout repository
     info "Cloning repo $repo ($mode $ref)..."
 
     if [ ! -d "$repo_path" ]; then
@@ -69,14 +86,22 @@ deploy() {
             git checkout FETCH_HEAD "${files[@]}"
         fi
     )
+
+    echo -n "$version" > "$version_path"
 }
 
-delete() {
-    true
+# check a list of files whether each file is checked out
+checkFiles() {
+    for file in "$@"; do
+        if [[ ! -e "$repo_path/$file" ]]; then
+            echo "$file"
+            return 1
+        fi
+    done
 }
 
 case "$1" in
-    deploy|prepare) deploy "$@";;
-    delete|cleanup) delete "$@";;
+    deploy|prepare) checkout "$@";;
+    delete|cleanup) checkout "$@";;
     *) fail "unsupported action $1"
 esac


### PR DESCRIPTION
The acre.yaml can now define a path to an installation handler script.
To do so, use this in your acre.yaml:
```yaml
meta:
  installationHandler:
    path: <path-to-executable-bash-file>
    config: <optional, arbitrary yaml>
```
The given path can be either absolute or relative to the landscape root directory.

If a script is given, it will be called once at the beginning (with argument `prepare`) and once at the end (with argument `finalize`) of each sow command (except for `sow version` and `sow help`).

If `installationHandler.config` is specified, its content will be given to the script as a second argument in form of a JSON string.