### PR TITLE
minor upgrades

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -18,9 +18,9 @@ RUN apk update && apk add --no-cache bash curl libc6-compat findutils apache2-ut
 RUN apk add git=2.20.1-r0
 RUN apk add terraform=0.11.8-r0
 RUN apk add jq=1.6-r0
-RUN curl -L -o /usr/bin/kubectl https://storage.googleapis.com/kubernetes-release/release/v1.13.5/bin/linux/amd64/kubectl
+RUN curl -L -o /usr/bin/kubectl https://storage.googleapis.com/kubernetes-release/release/v1.15.5/bin/linux/amd64/kubectl
 RUN curl -L -o /usr/bin/kustomize https://github.com/kubernetes-sigs/kustomize/releases/download/v3.1.0/kustomize_3.1.0_linux_amd64
-RUN curl -L -o helm-archive.tar.gz https://storage.googleapis.com/kubernetes-helm/helm-v2.13.0-linux-amd64.tar.gz \
+RUN curl -L -o helm-archive.tar.gz https://storage.googleapis.com/kubernetes-helm/helm-v2.15.1-linux-amd64.tar.gz \
     && mkdir helm-extract \
     && tar -xzf helm-archive.tar.gz -C helm-extract \
     && cp helm-extract/linux-amd64/helm /usr/bin/helm \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -19,6 +19,7 @@ RUN apk add git=2.20.1-r0
 RUN apk add terraform=0.11.8-r0
 RUN apk add jq=1.6-r0
 RUN curl -L -o /usr/bin/kubectl https://storage.googleapis.com/kubernetes-release/release/v1.13.5/bin/linux/amd64/kubectl
+RUN curl -L -o /usr/bin/kustomize https://github.com/kubernetes-sigs/kustomize/releases/download/v3.1.0/kustomize_3.1.0_linux_amd64
 RUN curl -L -o helm-archive.tar.gz https://storage.googleapis.com/kubernetes-helm/helm-v2.13.0-linux-amd64.tar.gz \
     && mkdir helm-extract \
     && tar -xzf helm-archive.tar.gz -C helm-extract \

--- a/lib/utils
+++ b/lib/utils
@@ -722,7 +722,7 @@ lookupFileIn() {
   esac
   local file="$1"
   shift
-  if [[ "$DIR" = /* ]]; then
+  if [[ "$file" = /* ]]; then
     echo "$file"
   else
     for d in "$@"; do

--- a/plugins/kubectl/utilities.yaml
+++ b/plugins/kubectl/utilities.yaml
@@ -66,9 +66,7 @@ utilities:
           name: current
         users:
         - name: (( values.username))
-          user:
-            client-certificate-data: (( base64(values.cert) ))
-            client-key-data: (( base64(values.key) ))
+          user: (( { "token" = values.token } || { "client-certificate-data" = base64(values.cert), "client-key-data" = base64(values.key) } ))
 
     kubeconfig: (( lambda |values|-> *_.templates.kubeconfig ))
 


### PR DESCRIPTION
- fix a bug that breaks the kustomize plugin
- update helm and kubectl binaries to newer versions
  - this is required to use sow on a kubernetes cluster of version 1.16 or higher
- extend the kubeconfig template in kubectl/utilities.yaml so that it can be used to create kubeconfigs with a service account token for authentication