### PR TITLE
add kubectl handler for serviceaccounts

### DIFF
--- a/plugins/kubectl/handlers/serviceaccount_resource
+++ b/plugins/kubectl/handlers/serviceaccount_resource
@@ -1,0 +1,55 @@
+# Copyright 2019 Copyright (c) 2019 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+action_deploy_ServiceAccount_core()
+{
+  exec_cmd kubectl --kubeconfig "$3" apply -f "$4" 
+  local token
+  local kconfig
+  if [ -z "$DRYRUN" ]; then
+    token="$(kubectl --kubeconfig "$3" -n "$2" get secret $(kubectl --kubeconfig "$3" -n "$2" get sa "$1" -o jsonpath={.secrets[0].name}) -o jsonpath={.data.token} | base64 -d)"
+    verbose "Writing kubeconfig with serviceaccount token to '$dir/sa_$1.kubeconfig'"
+    cat > "$dir/sa_$1.kubeconfig" << EOF
+---
+apiVersion: v1
+kind: Config
+current-context: cluster
+contexts:
+- context:
+    cluster: cluster
+    user: $1
+  name: cluster
+clusters:
+- cluster:
+$(spiff merge $3 --path=.clusters.$(spiff merge $3 --path=.current-context).cluster | indent 4)
+  name: cluster
+users:
+- name: $1
+  user:
+    token: $token
+EOF
+  fi
+}
+
+# reads from stdin and indents everything by the given number of spaces (default 2)
+indent() {
+  local ind=${1:-2}
+  local prefix=""
+  for i in $(seq 1 $ind); do
+    prefix=" $prefix"
+  done;
+  while read line ; do
+    echo "$prefix$line"
+  done
+}


### PR DESCRIPTION
The handler will generate a kubeconfig using the serviceaccount's token each time a serviceaccount is created using the kubectl plugin.