### PR TITLE
enhance helm plugin

### DIFF
--- a/plugins/helm/plugin
+++ b/plugins/helm/plugin
@@ -56,13 +56,16 @@ if [ -z "$src" ]; then
     fi
 fi
 
+# handle spiff templating of values file if necessary
+if [[ "$command" == "spiff" ]]; then
+    verbose "Using 'spiff merge' on values file ..."
+    sed -e 's/((! /(( /' <<< "$PLUGINCONFIGJSON" | spiff merge --path=.values --json - > "$dir/values.json"
+    command="${3:-"upgrade"}"
+fi
+
 deploy() {
     info "Running helm $command for $name ..."
     case "$command" in
-        spiff)
-            verbose "Using 'spiff merge' on values file ..."
-            sed -e 's/((! /(( /' <<< "$PLUGINCONFIGJSON" | spiff merge --path=.values --json - > "$dir/values.json"
-            ;&
         upgrade)
             while true; do
                 if exec_cmd helm upgrade --install --force --wait $name --kubeconfig "$KUBECONFIG" --values "$dir/values.json" --namespace $namespace $(echo "${helm_flags_deploy[@]}") "$src" ; then
@@ -89,9 +92,6 @@ deploy() {
 
 delete() {
     case "$command" in
-        spiff)
-            verbose "Skipping spiff merge of values file, as it is not needed during delete"
-            ;&
         upgrade)
             info "Deleting helm deployment for $name"
             tmp="/tmp/helmplugin$$"


### PR DESCRIPTION
The "spiff" subcommand has been modified. It now takes an (optional) additional subcommand.
Valid values for the additional subcommand are "upgrade" and "template". The default is "upgrade".

This change basically allows to use the "spiff" subcommand in combination with the "template" subcommand, which was not possible before.
**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
The `spiff` subcommand for the helm plugin can now be used in combination with the `template` subcommand.
```
