### PR TITLE
add namespace to rendered helm charts

### DIFF
--- a/plugins/helm/inject_namespace.yaml
+++ b/plugins/helm/inject_namespace.yaml
@@ -1,0 +1,8 @@
+temp:
+  <<: (( &temporary ))
+  inject_ns: (( |obj,ns|-> defined(obj.metadata.namespace) ? obj :sum[obj|{}|s,k,v|-> s ( k == "metadata" ? { k = v {"namespace" = ns} } :{ k = v } )] ))
+  files: (( read(path, "multiyaml") ))
+  namespace: (( env( "NAMESPACE" ) ))
+  path: (( env( "TEMPLATE_FILE" ) ))
+
+result: (( map[select[temp.files|elem|-> valid(elem)]|f|-> temp.inject_ns(f, temp.namespace)] ))

--- a/plugins/helm/plugin
+++ b/plugins/helm/plugin
@@ -130,6 +130,11 @@ helm_template() {
         # workaround - exec_cmd can't be used since it uses 'echo' (in verbose mode), which interferes with the pipe.
         echo "$cmd"
     fi
+    eval $(echo "$cmd") | dump "$dir/rendered_charts_raw.yaml"
+    cmd="TEMPLATE_FILE=\"$dir/rendered_charts_raw.yaml\" NAMESPACE=$namespace spiff merge \"$PLUGIN/inject_namespace.yaml\" --path result --split"
+    if [ -n "$VERBOSE" ]; then
+        echo "$cmd"
+    fi
     eval $(echo "$cmd") | dump "$dir/rendered_charts.yaml"
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Since `helm template` does not include the namespace given via its `--namespace` flag in the rendered manifests, `helm install` cannot be replaced by `helm template` with a `kubectl apply` afterwards, which caused the necessity for this workaround: https://github.com/gardener/garden-setup/pull/180

This PR adds a snippet that is applied via `spiff` to the manifests rendered with `helm template`. It will add the given namespace to all manifests that don't already include a `metadata.namespace` field. It will also be added to cluster-scoped resources this way, but `kubectl apply` ignores `metadata.namespace` on non-namespaced resources, so that shouldn't be a problem.

While the updated manifests will be available in the `rendered_manifests.yaml` file, the unmodified output of `helm template` can be found in the `rendered_manifests_raw.yaml` file.

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```action operator
The `template` subcommand of the `helm` plugin now contains a post-processing step that adds the provided namespace to all resource manifests where `metadata.namespace` is not already present, since `helm template` itself does not add namespaces to the manifests. As before, the output of the plugin will be available in a file called `rendered_manifests.yaml`. The unprocessed output of `helm template` can now be found in a file named `rendered_manifests_raw.yaml`. You will have to adapt your component if you rely on the unprocessed manifests.
```
