### PR TITLE
Fix sa kubeconfig

### DIFF
--- a/plugins/kubectl/handlers/serviceaccount_resource
+++ b/plugins/kubectl/handlers/serviceaccount_resource
@@ -12,9 +12,18 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-action_deploy_ServiceAccount_core()
-{
-  exec_cmd kubectl --kubeconfig "$3" apply -f "$4" 
+action_deploy_ServiceAccount_core() {
+  exec_cmd kubectl --kubeconfig "$3" apply -f "$4"
+  create_kubeconfig_for_sa "$@"
+}
+
+action_delete_ServiceAccount_core() {
+  create_kubeconfig_for_sa "$@"
+  exec_cmd kubectl --kubeconfig "$3" delete -f "$4"
+}
+
+# create kubeconfig for serviceaccount
+create_kubeconfig_for_sa() {
   local token
   local kconfig
   if [ -z "$DRYRUN" ]; then


### PR DESCRIPTION
https://github.com/gardener/sow/pull/27 introduced a handler for the kubectl plugin that creates a kubeconfig whenever a ServiceAccount is created via the plugin. This kubeconfig was stored in the `gen`, and if that folder had been deleted - which shouldn't cause any problems - the missing kubeconfig could cause the deletion to fail. To prevent this, the handler has been expanded to create the kubeconfig also on deletion.

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
The serviceaccount kubeconfig created automatically by a handler of the `kubectl` plugin is now also created on deletion.
```
