### PR TITLE
fix deletion of protected resources

### DIFF
--- a/plugins/kubectl/handlers/custom_resource_definitions
+++ b/plugins/kubectl/handlers/custom_resource_definitions
@@ -30,7 +30,7 @@ action_deploy_CustomResourceDefinition_apiextensions_k8s_io()
 action_delete_CustomResourceDefinition_apiextensions_k8s_io() {
     objs="$(kubectl --kubeconfig "$3" get --all-namespaces "$1" -o json | jq ".items | length")"
     if [ $objs -eq 0 ]; then
-      if [[ $(kubectl --kubeconfig "$3" get crd "$1" -o json | jq -r '.metadata.annotations["gardener.cloud/deletion-protected"]') == "true" ]]; then
+      if [[ $(kubectl --kubeconfig "$3" get crd "$1" -o json | jq -r '.metadata.labels["gardener.cloud/deletion-protected"]') == "true" ]]; then
         verbose "Annotate crd to enable deletion ..."
         exec_cmd kubectl --kubeconfig "$3" annotate crd "$1" "confirmation.gardener.cloud/deletion=true"
       fi


### PR DESCRIPTION
**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
Fixed a bug that prevented the deletion of resources protected with the `gardener.cloud/deletion-protected` label.
```
