### PR TITLE
check only '*.gardener.cloud' CRDs for deletion protection

### DIFF
--- a/plugins/kubectl/handlers/custom_resource_definitions
+++ b/plugins/kubectl/handlers/custom_resource_definitions
@@ -30,9 +30,11 @@ action_deploy_CustomResourceDefinition_apiextensions_k8s_io()
 action_delete_CustomResourceDefinition_apiextensions_k8s_io() {
     objs="$(kubectl --kubeconfig "$3" get --all-namespaces "$1" -o json | jq ".items | length")"
     if [ $objs -eq 0 ]; then
-      if [[ $(kubectl --kubeconfig "$3" get crd "$1" -o json | jq -r '.metadata.labels["gardener.cloud/deletion-protected"]') == "true" ]]; then
-        verbose "Annotate crd to enable deletion ..."
-        exec_cmd kubectl --kubeconfig "$3" annotate crd "$1" "confirmation.gardener.cloud/deletion=true"
+      if [[ ${1: -15} == ".gardener.cloud" ]]; then
+        if [[ $(kubectl --kubeconfig "$3" get crd "$1" -o json | jq -r '.metadata.labels["gardener.cloud/deletion-protected"]') == "true" ]]; then
+          verbose "Annotate crd to enable deletion ..."
+          exec_cmd kubectl --kubeconfig "$3" annotate crd "$1" "confirmation.gardener.cloud/deletion=true"
+        fi
       fi
       exec_cmd kubectl --kubeconfig "$3" delete crd "$1" --wait=false
     else


### PR DESCRIPTION
**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
To speed up CRD deletion, the CRD will now only be checked for the `gardener.cloud/deletion-protection` label if its full name ends with `.gardener.cloud`.
```
