### PR TITLE
terraform plugin: relative source + direct main spec

### DIFF
--- a/README.md
+++ b/README.md
@@ -524,8 +524,18 @@ shell scripts.
 There is a combined environment and command line interface for the execution
 of plugins.
 
+The first argument is always the action to perform:
+ 
+ `prepare`: for plugins in component.yaml
+ `deploy`: execute a deployment
+ `delete`: delete the former deployment
+ `cleanup`: for plugin in component.yaml
+
+There might be additional arguments accordin the plugin spec in the deployment.yaml.
+
 In the environment environment variables are provided for a dedicated execution:
 
+- `CURRENT`: The path to the component folder (also the actual working directory)
 - `DEPLOYMEMT`: The manifest file the plugin execution is taken from
 - `PLUGINCONFIG`: A file containing the configuration configured in the plugin
                   specification in the above manifest

--- a/bin/sow
+++ b/bin/sow
@@ -134,7 +134,7 @@ esac
 componentStub()
 {
   local __stub
-  jsonAddString __stub "<<" "(( &temporary ))"
+  jsonAddString __stub "<<" "(( &temporary &inject ))"
   jsonAddString __stub ROOTDIR "$ROOT"
   jsonAddString __stub ROOTPRODUCTDIR "$ROOTPRODUCTDIR"
   jsonAddString __stub PRODUCT "$PRODUCT"

--- a/lib/action
+++ b/lib/action
@@ -477,11 +477,14 @@ exec_plugin()
     return
   fi
 
-  getValue key path spec
+  getValue key key spec
   getValue cpath path spec
   getJSON config config spec
   getValueList args args spec
   
+  if [ -z "$key" ]; then
+    key="$cpath"
+  fi
   if [ -z "$key" ]; then
     if [ ${#args[@]} -gt 0 ]; then
       key="${args[0]}"

--- a/lib/utils
+++ b/lib/utils
@@ -93,6 +93,12 @@ handle_error()
     fi
     $h
   done
+
+  if [ -z "$INTENDED_EXIT" ]; then
+    if [ -n "$PLUGINCONFIG" -a -f "$PLUGINCONFIG" ]; then
+      rm -f "$PLUGINCONFIG"
+    fi
+  fi
 }
 
 addCleanupHandler()
@@ -401,6 +407,64 @@ executionLoop()
     fi
     "$1" "$cmd" $_i "${_values[$_i]}" "${@:2}"
   done
+}
+
+isAbsolutePath()
+{
+  test "${1#/}" != "$1"
+}
+
+################
+# get absolute path for a path
+#
+# $1 : relative filename (at least directory must exist)
+################
+abspath()
+{
+  if [ -d "$1" ]; then
+    ( cd "$1"; pwd )
+  else
+    local p="${1%%/}"
+    local t
+    while t="${p%%/.}"; [ "$p" != "$t" ]; do
+      p="${t%%/}"
+    done
+    p="$(cd "$(dirname "$p")" && pwd)/$(basename "$p")"
+    t="${p%%/..}"
+    [ "$t" == "$p" ] && echo "$p" || dirname "$t"
+  fi
+}
+
+################
+# get relative path
+# 
+# $1: base path   (from)
+# $2: target path (to)
+################
+relpath()
+{
+  [ $# -ge 1 -a $# -le 2 ] || Error two paths required
+  local current="${2:+"$1"}"
+  local target="${2:-"$1"}"
+  [ "$target" != . ] || target=/
+  target="/${target##/}"
+  [ "$current" != . ] || current=/
+  current="${current:="/"}"
+  current="/${current##/}"
+  local appendix="${target##/}"
+  local relative=''
+  while appendix="${target#"$current"/}"
+      [ "$current" != '/' ] && [ "$appendix" = "$target" ]; do
+      if [ "$current" = "$appendix" ]; then
+          relative="${relative:-.}"
+          echo "${relative#/}"
+          return 0
+      fi
+      current="${current%/*}"
+      relative="$relative${relative:+/}.."
+  done
+  relative="$relative${relative:+${appendix:+/}}${appendix#/}"
+  echo "$relative"
 }
 
 ############################################################################

--- a/plugins/terraform/README.md
+++ b/plugins/terraform/README.md
@@ -1,0 +1,16 @@
+
+## terraform plugin
+
+This plugin executes a terraform project as part of the deployment actions for a component.
+
+The config uses the following fields:
+
+| field | type | meaning |
+| ----- | ---- | ------- |
+| `source` | path | source path of the terraform project. This might be a relative path into the component folder. |
+| `main` | map | directly given terraform main module spec which is used as terraform project. A potential `modules` folder in the sources will be mapped to the generated project root and appropriate module calls can be done as for a regular terraform project. If multiple terraform plugins are used in a component, the lookup of the modules folder will be done taking the plugin instance key into account. |
+| `values` | map (required) | input values for the terraform project |
+
+Only one, `main` or `source` can be specified.
+
+

--- a/plugins/terraform/plugin
+++ b/plugins/terraform/plugin
@@ -20,9 +20,43 @@ source "$SOWLIB/pluginutils"
 
 jq .values <<< "$PLUGINCONFIGJSON" > "$dir/terraform.tfvars.json"
 
-getRequiredValue source source PLUGINCONFIGJSON
+getValue source source PLUGINCONFIGJSON
+getJSON main main PLUGINCONFIGJSON
+
+src="$CURRENT/$PLUGININSTANCE"
+
+if [ -z "$source" -a -z "$main" ]; then
+  source="$PLUGININSTANCE"
+fi
+if [ -n "$main" ]; then
+  if [ -n "$source" ]; then
+    fail "either a source folder (source) or a direct content (main) must be specified in plugin config"
+  fi
+  source="$dir/main"
+  mkdir -p "$source"
+  echo "$main" > "$source/main.tf.json"
+  if [ -d "$src/modules" ]; then
+    ln -s "$src/modules" "$source"
+  else 
+    if [ -d "$CURRENT/modules" ]; then
+      if [ ! -h "$source/modules" ]; then
+        ln -s "$CURRENT/modules" "$source"
+      fi
+    fi
+  fi
+else
+   if ! isAbsolutePath "$source"; then
+     if [ -d "$src/$source" ]; then
+       source="$src/$source"
+     else
+       source="$CURRENT/$source"
+     fi
+   fi
+fi
+  
 
 deploy() {
+    info "project is $source"
     (
         cd "$dir"
         exec_cmd terraform init "$source"


### PR DESCRIPTION
**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement user
The terraform plugin now supports the generation of the main module directly in the deployment.yaml.
Additionally the source field may now be a path relative to the component folder.
```
