### PR TITLE
Update kubectl in sow image to 1.17.16 to support cert-manager

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -20,7 +20,7 @@ RUN apk update && apk add --no-cache bash curl libc6-compat findutils apache2-ut
 RUN apk add git~=2.24
 RUN apk add terraform~=0.12
 RUN apk add jq~=1.6
-RUN curl -L -o /usr/bin/kubectl https://storage.googleapis.com/kubernetes-release/release/v1.17.9/bin/linux/${ARCH}/kubectl \
+RUN curl -L -o /usr/bin/kubectl https://storage.googleapis.com/kubernetes-release/release/v1.17.16/bin/linux/${ARCH}/kubectl \
     && chmod +x /usr/bin/kubectl
 RUN if [ "$ARCH" = "amd64" ] ; then curl -L -o kustomize-archive.tar.gz https://github.com/kubernetes-sigs/kustomize/releases/download/kustomize%2Fv3.5.4/kustomize_v3.5.4_linux_${ARCH}.tar.gz; \
     else curl -L -o kustomize-archive.tar.gz https://github.com/${GITHUB_PROFILE}/kustomize/releases/download/kustomize%2Fv3.5.4/kustomize_v3.5.4_linux_${ARCH}.tar.gz; fi \


### PR DESCRIPTION
**What this PR does / why we need it**:
This updates `kubectl` in the `sow` docker image to version `1.17.16`. This is required to apply CRDs for cert-manager `1.3.1` . Details here: https://cert-manager.io/docs/installation/upgrading/upgrading-0.15-0.16/  
**Which issue(s) this PR fixes**:
Fixes https://github.com/gardener/garden-setup/pull/445

**Special notes for your reviewer**:
This is cross dependency to https://github.com/gardener/garden-setup/pull/445
**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
Use newer kubectl in sow image to support cert-manager 1.3.1 crd deployments
```
