### PR TITLE
upgrade dependencies in Dockerfile

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -12,15 +12,15 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM alpine:3.11
+FROM alpine:3.13
 ARG ARCH=amd64
 ARG GITHUB_PROFILE=ezeeyahoo
 
 RUN apk update && apk add --no-cache bash curl libc6-compat findutils apache2-utils
-RUN apk add git~=2.24
-RUN apk add terraform~=0.12
+RUN apk add git~=2
+RUN apk add terraform~=0.14
 RUN apk add jq~=1.6
-RUN curl -L -o /usr/bin/kubectl https://storage.googleapis.com/kubernetes-release/release/v1.17.16/bin/linux/${ARCH}/kubectl \
+RUN curl -L -o /usr/bin/kubectl https://storage.googleapis.com/kubernetes-release/release/v1.18.18/bin/linux/${ARCH}/kubectl \
     && chmod +x /usr/bin/kubectl
 RUN if [ "$ARCH" = "amd64" ] ; then curl -L -o kustomize-archive.tar.gz https://github.com/kubernetes-sigs/kustomize/releases/download/kustomize%2Fv3.5.4/kustomize_v3.5.4_linux_${ARCH}.tar.gz; \
     else curl -L -o kustomize-archive.tar.gz https://github.com/${GITHUB_PROFILE}/kustomize/releases/download/kustomize%2Fv3.5.4/kustomize_v3.5.4_linux_${ARCH}.tar.gz; fi \
@@ -35,8 +35,8 @@ RUN curl -L -o helm-archive.tar.gz https://get.helm.sh/helm-v3.2.4-linux-${ARCH}
     && cp helm-extract/linux-${ARCH}/helm /usr/bin/helm \
     && rm -rf helm-archive.tar.gz helm-extract \
     && chmod +x /usr/bin/helm
-RUN if [ "$ARCH" = "amd64" ] ; then curl -L -o spiff-archive.zip https://github.com/mandelsoft/spiff/releases/download/v1.5.0/spiff_linux_${ARCH}.zip; \
-    else curl -L -o spiff-archive.zip https://github.com/${GITHUB_PROFILE}/spiff/releases/download/v1.5.0/spiff_linux_${ARCH}.zip; fi \
+RUN if [ "$ARCH" = "amd64" ] ; then curl -L -o spiff-archive.zip https://github.com/mandelsoft/spiff/releases/download/v1.6.1/spiff_linux_${ARCH}.zip; \
+    else curl -L -o spiff-archive.zip https://github.com/${GITHUB_PROFILE}/spiff/releases/download/v1.6.1/spiff_linux_${ARCH}.zip; fi \
     && mkdir spiff-extract \
     && unzip -d spiff-extract spiff-archive.zip \
     && cp "spiff-extract/spiff++" /usr/bin/spiff \


### PR DESCRIPTION
**What this PR does / why we need it**:
We need an upgrade of terraform, since the old version of the openstack terraform provider is not available anymore. This also requires upgrading the alpine image, which in turn requires changes to `git`. The `spiff` and `kubectl` versions do not necessarily need to be updated, but I don't see a reason not to.

**Special notes for your reviewer**:
@ezeeyahoo This requires you to rebase your fork of spiff to the newest version and create the `v1.6.1` release.
Maybe it would be a good idea if you create a PR for your changes on the "official" spiff repository, so we can get rid of this fork logic. @mandelsoft what do you think?
We would still need it for kustomize, but we wouldn't have to maintain two versions of spiff.

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```action operator
Several dependency versions have changed and might require changes in components that use the corresponding plugins (most notably: `terraform`).
```
```noteworthy operator
Upgrade terraform dependency to `0.14`
```
```noteworthy operator
Upgrade alpine base image to `3.13`
```
```noteworthy operator
Upgrade kubectl dependency to `v1.18.18`
```
```noteworthy operator
Upgrade spiff dependency to `v1.6.1`
```
```other operator
Upgrade git dependency
```
