### PR TITLE
Add kube cache folder

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -21,7 +21,7 @@ RUN apk add git~=2
 RUN apk add terraform~=0.14
 RUN apk add jq~=1.6
 RUN curl -L -o /usr/bin/kubectl https://storage.googleapis.com/kubernetes-release/release/v1.21.5/bin/linux/${ARCH}/kubectl \
-    && chmod +x /usr/bin/kubectl
+    && chmod +x /usr/bin/kubectl && mkdir -p /.kube/cache && chmod -R 777 /.kube
 RUN if [ "$ARCH" = "amd64" ] ; then curl -L -o kustomize-archive.tar.gz https://github.com/kubernetes-sigs/kustomize/releases/download/kustomize%2Fv3.5.4/kustomize_v3.5.4_linux_${ARCH}.tar.gz; \
     else curl -L -o kustomize-archive.tar.gz https://github.com/${GITHUB_PROFILE}/kustomize/releases/download/kustomize%2Fv3.5.4/kustomize_v3.5.4_linux_${ARCH}.tar.gz; fi \
     && mkdir kustomize-extract \


### PR DESCRIPTION
**What this PR does / why we need it**:
Add /.kube/cache folder to prevent client side throttling with kubectl. 

Without the cache folder these messages appear and the execution of kubectl stucks for some seconds:
```
I1228 08:21:32.817906 9391 request.go:668] Waited for 1.138721318s due to client-side throttling, not priority and fairness, request: GET:https://<api-url>/apis/someapi.io/v1?timeout=32s
```

**Release note**:
```improvement operator
Add cache folder to prevent client side throttling with kubectl
```
