### PR TITLE
build sow for multiple architectures

### DIFF
--- a/.ci/pipeline_definitions
+++ b/.ci/pipeline_definitions
@@ -7,6 +7,10 @@ sow-release:
         preprocess: 'finalize'
         inject_effective_version: true
       publish:
+        oci-builder: docker-buildx
+        platforms:
+        - linux/amd64
+        - linux/arm64
         dockerimages:
           sow:
             dockerfile: 'docker/Dockerfile'

--- a/Makefile
+++ b/Makefile
@@ -40,4 +40,4 @@ docker-image-ppc:
 
 .PHONY: docker-image-arm
 docker-image-arm:
-	@docker build --build-arg ARCH=arm64 -t $(IMAGE_REPOSITORY):$(IMAGE_TAG) -f docker/Dockerfile --rm .
+	@docker build --build-arg ARCH=arm64 -t $(IMAGE_REPOSITORY):$(IMAGE_TAG)-arm -f docker/Dockerfile --rm .


### PR DESCRIPTION
**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```feature operator
The `sow` image is now built for amd and arm architectures by default.
```
