### PR TITLE
fix too long argument list

### DIFF
--- a/bin/helper/pluginlist
+++ b/bin/helper/pluginlist
@@ -52,7 +52,7 @@ CMD_del()
 case "$1" in 
   reset) CMD_reset;;
   update) CMD_update last;;
-  deploy) CMD_set "$2" "$3";;
+  deploy) CMD_set "$2" "$(cat "$3")";;
   delete) CMD_del "$2";;
 esac
 

--- a/lib/action
+++ b/lib/action
@@ -570,14 +570,17 @@ exec_plugin()
             jsonAddString ajson "$a"
           done
           setjsonjson spec args "[ $ajson ]"
+          specfile=${TMP_NAME}$(sha1 "$spec")
+          echo "$spec" > "$specfile"
           if [ "$action" == deploy ]; then
-            synchronized "$SOW/bin/helper/pluginlist" $action "$key" "$spec"
+            synchronized "$SOW/bin/helper/pluginlist" $action "$key" "$specfile"
           fi
 
           __exec_plugin "${name}" "${key}" "$plugin" "${plugin_opts[@]}" "$action" "${args[@]}"
           if [ "$action" == delete ]; then
-            synchronized "$SOW/bin/helper/pluginlist" $action "$key" "$spec"
+            synchronized "$SOW/bin/helper/pluginlist" $action "$key" "$specfile"
           fi
+          rm -f "$specfile"
        else
          fail "no action function or plugin with name '${name}' found"
        fi

--- a/lib/utils
+++ b/lib/utils
@@ -1019,3 +1019,11 @@ isInternet()
 {
   [ "${1#https://}" != "$1" -o "${1#http://}" != "$1" ]
 }
+
+sha1()
+{
+  sha1sum <<< "$1" | (
+    read a b
+    echo "$a"
+  )
+}


### PR DESCRIPTION
**What this PR does / why we need it**:
Fixes a bug which can occur if the config for a plugin becomes too long.

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```bugfix user
Fixed an issue where sow would break if the config for a plugin was too long.
```
